### PR TITLE
Add Deno import aliases

### DIFF
--- a/components/cards/device-card-large.tsx
+++ b/components/cards/device-card-large.tsx
@@ -1,6 +1,6 @@
 import { PiQuestion } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 import { EmulationPerformance } from "../devices/emulation-performance.tsx";
 import { StarRating } from "../ratings/star-rating.tsx";
 import { CurrencyIcon } from "../shared/currency-icon.tsx";

--- a/components/cards/device-card-medium.tsx
+++ b/components/cards/device-card-medium.tsx
@@ -1,7 +1,7 @@
 import { PiQuestion } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { RatingInfo } from "../../islands/devices/rating-info.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { RatingInfo } from "@islands/devices/rating-info.tsx";
 import { CurrencyIcon } from "../shared/currency-icon.tsx";
 
 interface DeviceCardMediumProps {

--- a/components/cards/device-card-row.tsx
+++ b/components/cards/device-card-row.tsx
@@ -1,7 +1,7 @@
 import { PiQuestion } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { RatingInfo } from "../../islands/devices/rating-info.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { RatingInfo } from "@islands/devices/rating-info.tsx";
 import { CurrencyIcon } from "../shared/currency-icon.tsx";
 
 interface DeviceCardRowProps {

--- a/components/cards/device-card-small.tsx
+++ b/components/cards/device-card-small.tsx
@@ -1,4 +1,4 @@
-import { Device } from "../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { StarRating } from "../ratings/star-rating.tsx";
 
 interface DeviceCardSmallProps {

--- a/components/cards/device-comment-card.tsx
+++ b/components/cards/device-comment-card.tsx
@@ -1,4 +1,4 @@
-import { CommentContract } from "../../data/frontend/contracts/comment.contract.ts";
+import { CommentContract } from "@data/frontend/contracts/comment.contract.ts";
 import { ProfileImage } from "../auth/profile-image.tsx";
 
 interface DeviceCommentCardProps {

--- a/components/comparisons/device-comparison-result.tsx
+++ b/components/comparisons/device-comparison-result.tsx
@@ -7,10 +7,10 @@ import {
   PiSpeakerHigh,
   PiWifiHigh,
 } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { Ranking } from "../../data/frontend/models/ranking.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { RatingInfo } from "../../islands/devices/rating-info.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { Ranking } from "@data/frontend/models/ranking.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { RatingInfo } from "@islands/devices/rating-info.tsx";
 import { StarRating } from "../ratings/star-rating.tsx";
 import { CurrencyIcon } from "../shared/currency-icon.tsx";
 import { TagComponent } from "../shared/tag-component.tsx";

--- a/components/comparisons/device-comparison-text.tsx
+++ b/components/comparisons/device-comparison-text.tsx
@@ -1,5 +1,5 @@
 import { PiArticle } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 
 interface DeviceComparisonTextProps {
   devices: Device[];

--- a/components/devices/device-links.tsx
+++ b/components/devices/device-links.tsx
@@ -1,6 +1,6 @@
 import { PiCaretCircleDoubleDown } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
 export function DeviceLinks({ device }: { device: Device }) {
   return (

--- a/components/devices/emulation-performance.tsx
+++ b/components/devices/emulation-performance.tsx
@@ -1,11 +1,11 @@
 import { PiQuestionFill, PiVibrate } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
-import { Cooling } from "../../data/frontend/models/cooling.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { FavoriteButton } from "../../islands/buttons/favorite-button.tsx";
-import { ThumbsUp } from "../../islands/buttons/thumbs-up.tsx";
-import { RatingInfo } from "../../islands/devices/rating-info.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { Cooling } from "@data/frontend/models/cooling.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { FavoriteButton } from "@islands/buttons/favorite-button.tsx";
+import { ThumbsUp } from "@islands/buttons/thumbs-up.tsx";
+import { RatingInfo } from "@islands/devices/rating-info.tsx";
 
 interface EmulationPerformanceProps {
   device: Device;

--- a/components/ratings/star-rating.tsx
+++ b/components/ratings/star-rating.tsx
@@ -1,7 +1,7 @@
 import { PiStar, PiStarFill, PiStarHalfFill } from "@preact-icons/pi";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { ScoreCalculatorService } from "../../data/frontend/services/devices/score-calculator.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { ScoreCalculatorService } from "@data/frontend/services/devices/score-calculator.service.ts";
 
 interface StarRatingProps {
   device: Device;

--- a/components/shared/filter-tag.tsx
+++ b/components/shared/filter-tag.tsx
@@ -3,7 +3,7 @@ import { useState } from "preact/hooks";
 import {
   TAG_FRIENDLY_NAMES,
   TagModel,
-} from "../../data/frontend/models/tag.model.ts";
+} from "@data/frontend/models/tag.model.ts";
 
 export function FilterTag(
   { tag, type, href }: {

--- a/components/shared/pagination-nav.tsx
+++ b/components/shared/pagination-nav.tsx
@@ -4,7 +4,7 @@ import {
   PiCaretLeftBold,
   PiCaretRightBold,
 } from "@preact-icons/pi";
-import { TagModel } from "../../data/frontend/models/tag.model.ts";
+import { TagModel } from "@data/frontend/models/tag.model.ts";
 
 interface PaginationNavProps {
   pageNumber: number;

--- a/components/shared/tag-component.tsx
+++ b/components/shared/tag-component.tsx
@@ -2,7 +2,7 @@ import { PiTag } from "@preact-icons/pi";
 import {
   TAG_FRIENDLY_NAMES,
   TagModel,
-} from "../../data/frontend/models/tag.model.ts";
+} from "@data/frontend/models/tag.model.ts";
 
 export function TagComponent({ tag }: { tag: TagModel }) {
   const slug = tag.slug;

--- a/components/specifications/device-specs.tsx
+++ b/components/specifications/device-specs.tsx
@@ -1,4 +1,4 @@
-import { Device } from "../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { AudioSpecs } from "./sections/audio-specs.tsx";
 import { ConnectivitySpecs } from "./sections/connectivity-specs.tsx";
 import { ControlsSpecs } from "./sections/controls-specs.tsx";

--- a/components/specifications/sections/audio-specs.tsx
+++ b/components/specifications/sections/audio-specs.tsx
@@ -1,5 +1,5 @@
 import { PiSpeakerHigh } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { AudioTable } from "../tables/audio-table.tsx";
 
 interface AudioSpecsProps {

--- a/components/specifications/sections/connectivity-specs.tsx
+++ b/components/specifications/sections/connectivity-specs.tsx
@@ -1,5 +1,5 @@
 import { PiWifiHigh } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { ConnectivityTable } from "../tables/connectivity-table.tsx";
 
 interface ConnectivitySpecsProps {

--- a/components/specifications/sections/controls-specs.tsx
+++ b/components/specifications/sections/controls-specs.tsx
@@ -1,5 +1,5 @@
 import { PiGameController } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { ControlsTable } from "../tables/controls-table.tsx";
 
 interface ControlsSpecsProps {

--- a/components/specifications/sections/cooling-specs.tsx
+++ b/components/specifications/sections/cooling-specs.tsx
@@ -1,5 +1,5 @@
 import { PiFan } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { CoolingSpecsTable } from "../tables/cooling-specs-table.tsx";
 
 interface CoolingSpecsProps {

--- a/components/specifications/sections/display-specs.tsx
+++ b/components/specifications/sections/display-specs.tsx
@@ -1,5 +1,5 @@
 import { PiMonitor } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { DisplaySpecsTable } from "../tables/display-specs-table.tsx";
 
 interface DisplaySpecsProps {

--- a/components/specifications/sections/miscellaneous-specs.tsx
+++ b/components/specifications/sections/miscellaneous-specs.tsx
@@ -1,5 +1,5 @@
 import { PiGear } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { MiscellaneousSpecsTable } from "../tables/miscellaneous-specs-table.tsx";
 
 interface MiscellaneousSpecsProps {

--- a/components/specifications/sections/physical-specs.tsx
+++ b/components/specifications/sections/physical-specs.tsx
@@ -1,5 +1,5 @@
 import { PiRuler } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { PhysicalSpecsTable } from "../tables/physical-specs-table.tsx";
 
 interface PhysicalSpecsProps {

--- a/components/specifications/sections/processing-specs.tsx
+++ b/components/specifications/sections/processing-specs.tsx
@@ -1,5 +1,5 @@
 import { PiCpu } from "@preact-icons/pi";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { ProcessingSpecsTable } from "../tables/processing-specs-table.tsx";
 
 interface ProcessingSpecsProps {

--- a/components/specifications/tables/audio-table.tsx
+++ b/components/specifications/tables/audio-table.tsx
@@ -1,4 +1,4 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 
 interface AudioTableProps {
   device: Device;

--- a/components/specifications/tables/connectivity-table.tsx
+++ b/components/specifications/tables/connectivity-table.tsx
@@ -1,5 +1,5 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
 interface ConnectivityTableProps {
   device: Device;

--- a/components/specifications/tables/controls-table.tsx
+++ b/components/specifications/tables/controls-table.tsx
@@ -1,5 +1,5 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 interface ControlsTableProps {
   device: Device;
 }

--- a/components/specifications/tables/cooling-specs-table.tsx
+++ b/components/specifications/tables/cooling-specs-table.tsx
@@ -1,5 +1,5 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 import { PiFan, PiListThin, PiPipe, PiTabs } from "@preact-icons/pi";
 
 interface CoolingSpecsTableProps {

--- a/components/specifications/tables/display-specs-table.tsx
+++ b/components/specifications/tables/display-specs-table.tsx
@@ -1,5 +1,5 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 interface DisplaySpecsTableProps {
   device: Device;
 }

--- a/components/specifications/tables/miscellaneous-specs-table.tsx
+++ b/components/specifications/tables/miscellaneous-specs-table.tsx
@@ -1,4 +1,4 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 
 interface MiscellaneousSpecsTableProps {
   device: Device;

--- a/components/specifications/tables/physical-specs-table.tsx
+++ b/components/specifications/tables/physical-specs-table.tsx
@@ -1,6 +1,6 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { ShellMaterial } from "../../../data/frontend/models/physical.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { ShellMaterial } from "@data/frontend/models/physical.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
 interface PhysicalSpecsTableProps {
   device: Device;

--- a/components/specifications/tables/processing-specs-table.tsx
+++ b/components/specifications/tables/processing-specs-table.tsx
@@ -1,4 +1,4 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 
 interface ProcessingSpecsTableProps {
   device: Device;

--- a/components/specifications/tables/summary-table.tsx
+++ b/components/specifications/tables/summary-table.tsx
@@ -1,5 +1,5 @@
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
 interface SummaryTableProps {
   device: Device;

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -47,7 +47,11 @@
     "@cap.js/server": "npm:@cap.js/server@^1.0.15",
     "@cap.js/widget": "npm:@cap.js/widget@^0.1.13",
     "pocketbase": "npm:pocketbase@^0.26.0",
-    "unique-names-generator": "npm:unique-names-generator@^4.7.1"
+    "unique-names-generator": "npm:unique-names-generator@^4.7.1",
+    "@components/": "./components/",
+    "@data/": "./data/",
+    "@islands/": "./islands/",
+    "@interfaces/": "./interfaces/"
   },
   "compilerOptions": {
     "lib": [

--- a/interfaces/state.ts
+++ b/interfaces/state.ts
@@ -1,4 +1,4 @@
-import type { User } from "../data/frontend/contracts/user.contract.ts";
+import type { User } from "@data/frontend/contracts/user.contract.ts";
 
 export interface SeoData {
   title?: string;

--- a/islands/charts/devices-per-brand-bar-chart.tsx
+++ b/islands/charts/devices-per-brand-bar-chart.tsx
@@ -1,5 +1,5 @@
 import { useState } from "preact/hooks";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { FreshChart } from "./fresh-chart.tsx";
 
 interface BarChartProps {

--- a/islands/charts/devices-per-ranking-bar-chart.tsx
+++ b/islands/charts/devices-per-ranking-bar-chart.tsx
@@ -1,4 +1,4 @@
-import { Device } from "../../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 import { FreshChart } from "./fresh-chart.tsx";
 
 interface BarChartProps {

--- a/islands/charts/devices-per-release-year-line-chart.tsx
+++ b/islands/charts/devices-per-release-year-line-chart.tsx
@@ -1,6 +1,6 @@
 import { useState } from "preact/hooks";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { getBrandColors } from "../../data/frontend/services/utils/color.utils.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { getBrandColors } from "@data/frontend/services/utils/color.utils.ts";
 import { FreshChart } from "./fresh-chart.tsx";
 
 interface LineChartProps {

--- a/islands/charts/devices-radar-chart.tsx
+++ b/islands/charts/devices-radar-chart.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "preact/hooks";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { RatingsService } from "../../data/frontend/services/devices/ratings.service.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { RatingsService } from "@data/frontend/services/devices/ratings.service.ts";
 import { FreshChart } from "./fresh-chart.tsx";
-import { Ranking } from "../../data/frontend/models/ranking.model.ts";
+import { Ranking } from "@data/frontend/models/ranking.model.ts";
 
 interface RadarChartProps {
   devices: Device[];

--- a/islands/charts/devices-similar-radar-chart.tsx
+++ b/islands/charts/devices-similar-radar-chart.tsx
@@ -1,5 +1,5 @@
 import { useState } from "preact/hooks";
-import type { Device } from "../../data/frontend/contracts/device.model.ts";
+import type { Device } from "@data/frontend/contracts/device.model.ts";
 import { DevicesRadarChart } from "./devices-radar-chart.tsx";
 
 interface DevicesSimilarRadarChartProps {

--- a/islands/collections/collection-card.tsx
+++ b/islands/collections/collection-card.tsx
@@ -1,7 +1,7 @@
 import { PiEye, PiPencil, PiTrash, PiX } from "@preact-icons/pi";
 import { useState } from "preact/hooks";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { DeviceCollection } from "../../data/frontend/contracts/device-collection.ts";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { DeviceCollection } from "@data/frontend/contracts/device-collection.ts";
 import { ShareButton } from "../buttons/share-button.tsx";
 export function CollectionCard(
   { collection }: { collection: DeviceCollection },

--- a/islands/collections/collection-create-form.tsx
+++ b/islands/collections/collection-create-form.tsx
@@ -1,8 +1,8 @@
 import { PiFloppyDisk } from "@preact-icons/pi";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { searchDevices } from "../../data/frontend/services/utils/search.utils.ts";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
 
 export function CollectionCreateForm(
   { devices }: { devices: Device[] },

--- a/islands/collections/collection-update-form.tsx
+++ b/islands/collections/collection-update-form.tsx
@@ -1,10 +1,10 @@
 import { PiFloppyDisk, PiTrash } from "@preact-icons/pi";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { DeviceCollection } from "../../data/frontend/contracts/device-collection.ts";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { searchDevices } from "../../data/frontend/services/utils/search.utils.ts";
-import { createLoggedInPocketBaseService } from "../../data/pocketbase/pocketbase.service.ts";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
+import { DeviceCollection } from "@data/frontend/contracts/device-collection.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
+import { createLoggedInPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
 
 export function CollectionUpdateForm(
   { allDevices, existingCollectionDevices, collection }: {

--- a/islands/collections/device-collections.tsx
+++ b/islands/collections/device-collections.tsx
@@ -1,4 +1,4 @@
-import { DeviceCollection } from "../../data/frontend/contracts/device-collection.ts";
+import { DeviceCollection } from "@data/frontend/contracts/device-collection.ts";
 import { CollectionCard } from "./collection-card.tsx";
 
 interface DeviceCollectionsProps {

--- a/islands/devices/rating-info.tsx
+++ b/islands/devices/rating-info.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
-import { EmulationSystemShort } from "../../data/frontend/enums/emulation-system.ts";
-import { SystemRating } from "../../data/frontend/models/system-rating.model.ts";
+import { EmulationSystemShort } from "@data/frontend/enums/emulation-system.ts";
+import { SystemRating } from "@data/frontend/models/system-rating.model.ts";
 import { IS_BROWSER } from "fresh/runtime";
 
 interface RatingInfoProps {

--- a/islands/devices/timeline-content.tsx
+++ b/islands/devices/timeline-content.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 
 interface TimelineContentProps {
   upcomingDevices: Device[];

--- a/islands/forms/add-device-comment-form.tsx
+++ b/islands/forms/add-device-comment-form.tsx
@@ -1,8 +1,8 @@
 import { PiPaperPlaneRight } from "@preact-icons/pi";
 import { useState } from "preact/hooks";
-import { ProfileImage } from "../../components/auth/profile-image.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
+import { ProfileImage } from "@components/auth/profile-image.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
 
 export function AddDeviceCommentForm({
   device,

--- a/islands/forms/add-device-review-form.tsx
+++ b/islands/forms/add-device-review-form.tsx
@@ -1,8 +1,8 @@
 import { PiPaperPlaneRight } from "@preact-icons/pi";
 import { useState } from "preact/hooks";
-import { ProfileImage } from "../../components/auth/profile-image.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
+import { ProfileImage } from "@components/auth/profile-image.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
 
 const RATING_FIELDS = [
   { name: "performance_rating", label: "Performance" },

--- a/islands/forms/device-comparison-form.tsx
+++ b/islands/forms/device-comparison-form.tsx
@@ -1,8 +1,8 @@
 import { PiGitDiff } from "@preact-icons/pi";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { searchDevices } from "../../data/frontend/services/utils/search.utils.ts";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
 
 export function DeviceComparisonForm({
   allDevices,

--- a/islands/forms/device-search-form.tsx
+++ b/islands/forms/device-search-form.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
-import { TagModel } from "../../data/frontend/models/tag.model.ts";
-import { UmamiService } from "../../data/frontend/services/umami/umami.service.ts";
+import { TagModel } from "@data/frontend/models/tag.model.ts";
+import { UmamiService } from "@data/frontend/services/umami/umami.service.ts";
 
 interface DeviceSearchFormProps {
   initialSearch: string;

--- a/islands/forms/tag-type-ahead.tsx
+++ b/islands/forms/tag-type-ahead.tsx
@@ -1,10 +1,10 @@
 import { PiTag, PiX } from "@preact-icons/pi";
 import { useEffect, useState } from "preact/hooks";
-import { FilterTag } from "../../components/shared/filter-tag.tsx";
+import { FilterTag } from "@components/shared/filter-tag.tsx";
 import {
   TAG_FRIENDLY_NAMES,
   TagModel,
-} from "../../data/frontend/models/tag.model.ts";
+} from "@data/frontend/models/tag.model.ts";
 
 interface TagTypeaheadProps {
   allTags: TagModel[];

--- a/islands/navigation/desktop-nav.tsx
+++ b/islands/navigation/desktop-nav.tsx
@@ -10,12 +10,12 @@ import {
   PiSignIn,
 } from "@preact-icons/pi";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { ProfileImage } from "../../components/auth/profile-image.tsx";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
-import { navigationItems } from "../../data/frontend/navigation-items.ts";
-import { searchDevices } from "../../data/frontend/services/utils/search.utils.ts";
+import { ProfileImage } from "@components/auth/profile-image.tsx";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { navigationItems } from "@data/frontend/navigation-items.ts";
+import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
 import { ThemeSwitcher } from "./theme-switcher.tsx";
 
 export function DesktopNav(

--- a/islands/navigation/mobile-nav.tsx
+++ b/islands/navigation/mobile-nav.tsx
@@ -11,12 +11,12 @@ import {
   PiSignIn,
 } from "@preact-icons/pi";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { ProfileImage } from "../../components/auth/profile-image.tsx";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
-import { navigationItems } from "../../data/frontend/navigation-items.ts";
-import { searchDevices } from "../../data/frontend/services/utils/search.utils.ts";
+import { ProfileImage } from "@components/auth/profile-image.tsx";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { navigationItems } from "@data/frontend/navigation-items.ts";
+import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
 import { ThemeSwitcher } from "./theme-switcher.tsx";
 
 export function MobileNav(

--- a/islands/navigation/top-navbar.tsx
+++ b/islands/navigation/top-navbar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "@preact/hooks";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
 import { DesktopNav } from "./desktop-nav.tsx";
 import { MobileNav } from "./mobile-nav.tsx";
 

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -1,10 +1,10 @@
 import { FreshContext, page } from "fresh";
-import { Device } from "../data/frontend/contracts/device.model.ts";
-import { User } from "../data/frontend/contracts/user.contract.ts";
-import { DeviceService } from "../data/frontend/services/devices/device.service.ts";
-import { CustomFreshState } from "../interfaces/state.ts";
-import { Footer } from "../components/footer.tsx";
-import { TopNavbar } from "../islands/navigation/top-navbar.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { Footer } from "@components/footer.tsx";
+import { TopNavbar } from "@islands/navigation/top-navbar.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/_error.tsx
+++ b/routes/_error.tsx
@@ -1,5 +1,5 @@
 import { FreshContext, HttpError, page, PageProps } from "fresh";
-import { CustomFreshState } from "../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,8 +1,8 @@
 // deno-lint-ignore-file
 import { FreshContext } from "fresh";
-import { createPocketBaseService } from "../data/pocketbase/pocketbase.service.ts";
-import { logJson, tracer } from "../data/tracing/tracer.ts";
-import { CustomFreshState } from "../interfaces/state.ts";
+import { createPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { logJson, tracer } from "@data/tracing/tracer.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 // List of file extensions to ignore for logging
 const IGNORED_EXTENSIONS = new Set([

--- a/routes/about/index.tsx
+++ b/routes/about/index.tsx
@@ -7,8 +7,8 @@ import {
   PiUsers,
 } from "@preact-icons/pi";
 import { FreshContext } from "fresh";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { VersionTag } from "../../components/shared/version-tag.tsx";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { VersionTag } from "@components/shared/version-tag.tsx";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/api/auth/discord/callback.ts
+++ b/routes/api/auth/discord/callback.ts
@@ -1,8 +1,8 @@
 import { setCookie } from "@std/http/cookie";
 import { FreshContext } from "fresh";
-import pkceSessionService from "../../../../data/pkce/pkce.service.ts";
-import { createPocketBaseService } from "../../../../data/pocketbase/pocketbase.service.ts";
-import { logJson, tracer } from "../../../../data/tracing/tracer.ts";
+import pkceSessionService from "@data/pkce/pkce.service.ts";
+import { createPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { logJson, tracer } from "@data/tracing/tracer.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/api/auth/discord/index.ts
+++ b/routes/api/auth/discord/index.ts
@@ -2,8 +2,8 @@ import { FreshContext } from "fresh";
 import pkceSessionService, {
   generateCodeChallenge,
   generateCodeVerifier,
-} from "../../../../data/pkce/pkce.service.ts";
-import { logJson, tracer } from "../../../../data/tracing/tracer.ts";
+} from "@data/pkce/pkce.service.ts";
+import { logJson, tracer } from "@data/tracing/tracer.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/api/auth/google/callback.ts
+++ b/routes/api/auth/google/callback.ts
@@ -5,9 +5,9 @@ import {
   NumberDictionary,
   uniqueNamesGenerator,
 } from "unique-names-generator";
-import pkceSessionService from "../../../../data/pkce/pkce.service.ts";
-import { createPocketBaseService } from "../../../../data/pocketbase/pocketbase.service.ts";
-import { logJson, tracer } from "../../../../data/tracing/tracer.ts";
+import pkceSessionService from "@data/pkce/pkce.service.ts";
+import { createPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { logJson, tracer } from "@data/tracing/tracer.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/api/auth/google/index.ts
+++ b/routes/api/auth/google/index.ts
@@ -1,9 +1,9 @@
 import {
   generateCodeChallenge,
   generateCodeVerifier,
-} from "../../../../data/pkce/pkce.service.ts";
-import pkceSessionService from "../../../../data/pkce/pkce.service.ts";
-import { logJson, tracer } from "../../../../data/tracing/tracer.ts";
+} from "@data/pkce/pkce.service.ts";
+import pkceSessionService from "@data/pkce/pkce.service.ts";
+import { logJson, tracer } from "@data/tracing/tracer.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/auth/sign-in.ts
+++ b/routes/api/auth/sign-in.ts
@@ -1,6 +1,6 @@
 import { setCookie } from "@std/http/cookie";
-import { ProblemDetail } from "../../../data/frontend/contracts/problem-detail.ts";
-import { createPocketBaseService } from "../../../data/pocketbase/pocketbase.service.ts";
+import { ProblemDetail } from "@data/frontend/contracts/problem-detail.ts";
+import { createPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/auth/sign-up.ts
+++ b/routes/api/auth/sign-up.ts
@@ -1,7 +1,7 @@
-import { createPocketBaseService } from "../../../data/pocketbase/pocketbase.service.ts";
-import { ProblemDetail } from "../../../data/frontend/contracts/problem-detail.ts";
+import { createPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { ProblemDetail } from "@data/frontend/contracts/problem-detail.ts";
 
-import cap from "../../../data/cap/cap.service.ts";
+import cap from "@data/cap/cap.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/captcha/challenge.ts
+++ b/routes/api/captcha/challenge.ts
@@ -1,4 +1,4 @@
-import cap from "../../../data/cap/cap.service.ts";
+import cap from "@data/cap/cap.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/captcha/redeem.ts
+++ b/routes/api/captcha/redeem.ts
@@ -1,4 +1,4 @@
-import cap from "../../../data/cap/cap.service.ts";
+import cap from "@data/cap/cap.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/captcha/validate.ts
+++ b/routes/api/captcha/validate.ts
@@ -1,4 +1,4 @@
-import cap from "../../../data/cap/cap.service.ts";
+import cap from "@data/cap/cap.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/collections/[id].ts
+++ b/routes/api/collections/[id].ts
@@ -1,7 +1,7 @@
-import { User } from "../../../data/frontend/contracts/user.contract.ts";
-import { createSuperUserPocketBaseService } from "../../../data/pocketbase/pocketbase.service.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
-import { CustomFreshState } from "../../../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   async PUT(ctx: FreshContext) {

--- a/routes/api/collections/index.ts
+++ b/routes/api/collections/index.ts
@@ -1,7 +1,7 @@
-import { User } from "../../../data/frontend/contracts/user.contract.ts";
-import { createSuperUserPocketBaseService } from "../../../data/pocketbase/pocketbase.service.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
-import { CustomFreshState } from "../../../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   async POST(ctx: FreshContext) {

--- a/routes/api/devices/[id]/favorite.ts
+++ b/routes/api/devices/[id]/favorite.ts
@@ -1,8 +1,8 @@
-import { ProblemDetail } from "../../../../data/frontend/contracts/problem-detail.ts";
+import { ProblemDetail } from "@data/frontend/contracts/problem-detail.ts";
 import {
   createLoggedInPocketBaseService,
   createSuperUserPocketBaseService,
-} from "../../../../data/pocketbase/pocketbase.service.ts";
+} from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/devices/[id]/like.ts
+++ b/routes/api/devices/[id]/like.ts
@@ -1,5 +1,5 @@
-import { ProblemDetail } from "../../../../data/frontend/contracts/problem-detail.ts";
-import { createLoggedInPocketBaseService } from "../../../../data/pocketbase/pocketbase.service.ts";
+import { ProblemDetail } from "@data/frontend/contracts/problem-detail.ts";
+import { createLoggedInPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/devices/[id]/likes.ts
+++ b/routes/api/devices/[id]/likes.ts
@@ -1,5 +1,5 @@
-import { ProblemDetail } from "../../../../data/frontend/contracts/problem-detail.ts";
-import { createSuperUserPocketBaseService } from "../../../../data/pocketbase/pocketbase.service.ts";
+import { ProblemDetail } from "@data/frontend/contracts/problem-detail.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/devices/[name].ts
+++ b/routes/api/devices/[name].ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-console
 import { FreshContext } from "fresh";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/api/devices/comments/index.ts
+++ b/routes/api/devices/comments/index.ts
@@ -1,4 +1,4 @@
-import { createSuperUserPocketBaseService } from "../../../../data/pocketbase/pocketbase.service.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/devices/index.ts
+++ b/routes/api/devices/index.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-console
 import { FreshContext } from "fresh";
-import { TagModel } from "../../../data/frontend/models/tag.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
+import { TagModel } from "@data/frontend/models/tag.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/api/devices/reviews/index.ts
+++ b/routes/api/devices/reviews/index.ts
@@ -1,4 +1,4 @@
-import { createSuperUserPocketBaseService } from "../../../../data/pocketbase/pocketbase.service.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { FreshContext } from "fresh";
 
 export const handler = {

--- a/routes/api/suggestions.ts
+++ b/routes/api/suggestions.ts
@@ -1,11 +1,11 @@
 // deno-lint-ignore-file no-console
 import { FreshContext } from "fresh";
-import { ProblemDetail } from "../../data/frontend/contracts/problem-detail.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
+import { ProblemDetail } from "@data/frontend/contracts/problem-detail.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
 import {
   createLoggedInPocketBaseService,
-} from "../../data/pocketbase/pocketbase.service.ts";
-import { CustomFreshState } from "../../interfaces/state.ts";
+} from "@data/pocketbase/pocketbase.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 interface SuggestionPayload {
   user: string;

--- a/routes/auth/sign-in.tsx
+++ b/routes/auth/sign-in.tsx
@@ -1,6 +1,6 @@
 import { FreshContext, page, PageProps } from "fresh";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { SignIn } from "../../islands/auth/sign-in.tsx";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { SignIn } from "@islands/auth/sign-in.tsx";
 
 export default function SignInPage(pageProps: PageProps) {
   const error = pageProps.url.searchParams.get("error");

--- a/routes/auth/sign-up.tsx
+++ b/routes/auth/sign-up.tsx
@@ -1,6 +1,6 @@
 import { FreshContext, page } from "fresh";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { SignUp } from "../../islands/auth/sign-up.tsx";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { SignUp } from "@islands/auth/sign-up.tsx";
 
 export default function SignUpPage() {
   const baseApiUrl = Deno.env.get("BASE_API_URL")!;

--- a/routes/charts/index.tsx
+++ b/routes/charts/index.tsx
@@ -1,9 +1,9 @@
 import { FreshContext, page } from "fresh";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
 
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { DevicesPerBrandBarChart } from "../../islands/charts/devices-per-brand-bar-chart.tsx";
-import { DevicesPerRatingBarChart } from "../../islands/charts/devices-per-ranking-bar-chart.tsx";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { DevicesPerBrandBarChart } from "@islands/charts/devices-per-brand-bar-chart.tsx";
+import { DevicesPerRatingBarChart } from "@islands/charts/devices-per-ranking-bar-chart.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/collections/[id]/index.tsx
+++ b/routes/collections/[id]/index.tsx
@@ -1,10 +1,10 @@
 import { FreshContext, page } from "fresh";
 import { RecordModel } from "npm:pocketbase";
-import { DeviceCardMedium } from "../../../components/cards/device-card-medium.tsx";
-import { DeviceCollection } from "../../../data/frontend/contracts/device-collection.ts";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { createSuperUserPocketBaseService } from "../../../data/pocketbase/pocketbase.service.ts";
-import { CustomFreshState } from "../../../interfaces/state.ts";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { DeviceCollection } from "@data/frontend/contracts/device-collection.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/collections/[id]/update.tsx
+++ b/routes/collections/[id]/update.tsx
@@ -1,10 +1,10 @@
 import { FreshContext, page } from "fresh";
-import { DeviceCollection } from "../../../data/frontend/contracts/device-collection.ts";
-import { Device } from "../../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../../data/frontend/services/devices/device.service.ts";
-import { createLoggedInPocketBaseService } from "../../../data/pocketbase/pocketbase.service.ts";
-import { CollectionUpdateForm } from "../../../islands/collections/collection-update-form.tsx";
-import { CustomFreshState } from "../../../interfaces/state.ts";
+import { DeviceCollection } from "@data/frontend/contracts/device-collection.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { createLoggedInPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { CollectionUpdateForm } from "@islands/collections/collection-update-form.tsx";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/collections/create.tsx
+++ b/routes/collections/create.tsx
@@ -1,7 +1,7 @@
 import { FreshContext, page } from "fresh";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { CollectionCreateForm } from "../../islands/collections/collection-create-form.tsx";
-import { CustomFreshState } from "../../interfaces/state.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { CollectionCreateForm } from "@islands/collections/collection-create-form.tsx";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/compare/index.tsx
+++ b/routes/compare/index.tsx
@@ -2,15 +2,15 @@ import { FreshContext } from "fresh";
 
 import { PiChartLine, PiInfo } from "@preact-icons/pi";
 import { page } from "fresh";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { Ranking } from "../../data/frontend/models/ranking.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { RatingsService } from "../../data/frontend/services/devices/ratings.service.ts";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { DevicesRadarChart } from "../../islands/charts/devices-radar-chart.tsx";
-import { DeviceComparisonForm } from "../../islands/forms/device-comparison-form.tsx";
-import { DeviceComparisonResult } from "../../components/comparisons/device-comparison-result.tsx";
-import { DeviceComparisonText } from "../../components/comparisons/device-comparison-text.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { Ranking } from "@data/frontend/models/ranking.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { RatingsService } from "@data/frontend/services/devices/ratings.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { DevicesRadarChart } from "@islands/charts/devices-radar-chart.tsx";
+import { DeviceComparisonForm } from "@islands/forms/device-comparison-form.tsx";
+import { DeviceComparisonResult } from "@components/comparisons/device-comparison-result.tsx";
+import { DeviceComparisonText } from "@components/comparisons/device-comparison-text.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/contact.tsx
+++ b/routes/contact.tsx
@@ -8,7 +8,7 @@ import {
   PiLinkedinLogo,
 } from "@preact-icons/pi";
 import { FreshContext, page } from "fresh";
-import { CustomFreshState } from "../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/devices/[name].tsx
+++ b/routes/devices/[name].tsx
@@ -6,31 +6,31 @@ import {
   PiStar,
 } from "@preact-icons/pi";
 import { FreshContext, page } from "fresh";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { DeviceCommentCard } from "../../components/cards/device-comment-card.tsx";
-import { DeviceReviewCard } from "../../components/cards/device-review-card.tsx";
-import { DeviceLinks } from "../../components/devices/device-links.tsx";
-import { EmulationPerformance } from "../../components/devices/emulation-performance.tsx";
-import { StarRating } from "../../components/ratings/star-rating.tsx";
-import { CurrencyIcon } from "../../components/shared/currency-icon.tsx";
-import { TagComponent } from "../../components/shared/tag-component.tsx";
-import { DeviceSpecs } from "../../components/specifications/device-specs.tsx";
-import { SummaryTable } from "../../components/specifications/tables/summary-table.tsx";
-import { CommentContract } from "../../data/frontend/contracts/comment.contract.ts";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { ReviewContract } from "../../data/frontend/contracts/review.contract.ts";
-import { User } from "../../data/frontend/contracts/user.contract.ts";
-import { BrandWebsites } from "../../data/frontend/enums/brand-websites.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { createSuperUserPocketBaseService } from "../../data/pocketbase/pocketbase.service.ts";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { BackButton } from "../../islands/buttons/back-button.tsx";
-import { ClipboardButton } from "../../islands/buttons/clipboard-button.tsx";
-import { CompareButton } from "../../islands/buttons/compare-button.tsx";
-import { ShareButton } from "../../islands/buttons/share-button.tsx";
-import { DevicesSimilarRadarChart } from "../../islands/charts/devices-similar-radar-chart.tsx";
-import { AddDeviceCommentForm } from "../../islands/forms/add-device-comment-form.tsx";
-import { AddDeviceReviewForm } from "../../islands/forms/add-device-review-form.tsx";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { DeviceCommentCard } from "@components/cards/device-comment-card.tsx";
+import { DeviceReviewCard } from "@components/cards/device-review-card.tsx";
+import { DeviceLinks } from "@components/devices/device-links.tsx";
+import { EmulationPerformance } from "@components/devices/emulation-performance.tsx";
+import { StarRating } from "@components/ratings/star-rating.tsx";
+import { CurrencyIcon } from "@components/shared/currency-icon.tsx";
+import { TagComponent } from "@components/shared/tag-component.tsx";
+import { DeviceSpecs } from "@components/specifications/device-specs.tsx";
+import { SummaryTable } from "@components/specifications/tables/summary-table.tsx";
+import { CommentContract } from "@data/frontend/contracts/comment.contract.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { ReviewContract } from "@data/frontend/contracts/review.contract.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { BrandWebsites } from "@data/frontend/enums/brand-websites.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { BackButton } from "@islands/buttons/back-button.tsx";
+import { ClipboardButton } from "@islands/buttons/clipboard-button.tsx";
+import { CompareButton } from "@islands/buttons/compare-button.tsx";
+import { ShareButton } from "@islands/buttons/share-button.tsx";
+import { DevicesSimilarRadarChart } from "@islands/charts/devices-similar-radar-chart.tsx";
+import { AddDeviceCommentForm } from "@islands/forms/add-device-comment-form.tsx";
+import { AddDeviceReviewForm } from "@islands/forms/add-device-review-form.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/devices/index.tsx
+++ b/routes/devices/index.tsx
@@ -1,15 +1,15 @@
 import { FreshContext, page } from "fresh";
-import { DeviceCardLarge } from "../../components/cards/device-card-large.tsx";
-import { DeviceCardRow } from "../../components/cards/device-card-row.tsx";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { PaginationNav } from "../../components/shared/pagination-nav.tsx";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { TagModel } from "../../data/frontend/models/tag.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { DeviceSearchForm } from "../../islands/forms/device-search-form.tsx";
-import { LayoutSelector } from "../../islands/forms/layout-selector.tsx";
-import { TagTypeahead } from "../../islands/forms/tag-type-ahead.tsx";
+import { DeviceCardLarge } from "@components/cards/device-card-large.tsx";
+import { DeviceCardRow } from "@components/cards/device-card-row.tsx";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { PaginationNav } from "@components/shared/pagination-nav.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { TagModel } from "@data/frontend/models/tag.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { DeviceSearchForm } from "@islands/forms/device-search-form.tsx";
+import { LayoutSelector } from "@islands/forms/layout-selector.tsx";
+import { TagTypeahead } from "@islands/forms/tag-type-ahead.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/faq/index.tsx
+++ b/routes/faq/index.tsx
@@ -1,6 +1,6 @@
 import { PiChartLine, PiInfo, PiQuestion } from "@preact-icons/pi";
 import { FreshContext, page } from "fresh";
-import { CustomFreshState } from "../../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -9,17 +9,17 @@ import {
   PiUserCheck,
 } from "@preact-icons/pi";
 import { FreshContext, page } from "fresh";
-import { DeviceCardMedium } from "../components/cards/device-card-medium.tsx";
-import { SeeMoreCard } from "../components/cards/see-more-card.tsx";
-import { TagComponent } from "../components/shared/tag-component.tsx";
-import { Device } from "../data/frontend/contracts/device.model.ts";
-import { User } from "../data/frontend/contracts/user.contract.ts";
-import { BrandWebsites } from "../data/frontend/enums/brand-websites.ts";
-import { TagModel } from "../data/frontend/models/tag.model.ts";
-import { DeviceService } from "../data/frontend/services/devices/device.service.ts";
-import { tracer } from "../data/tracing/tracer.ts";
-import { CustomFreshState } from "../interfaces/state.ts";
-import { Hero } from "../islands/hero/hero.tsx";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { SeeMoreCard } from "@components/cards/see-more-card.tsx";
+import { TagComponent } from "@components/shared/tag-component.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { User } from "@data/frontend/contracts/user.contract.ts";
+import { BrandWebsites } from "@data/frontend/enums/brand-websites.ts";
+import { TagModel } from "@data/frontend/models/tag.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { tracer } from "@data/tracing/tracer.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { Hero } from "@islands/hero/hero.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/leaderboard.tsx
+++ b/routes/leaderboard.tsx
@@ -1,10 +1,10 @@
 import { FreshContext, page } from "fresh";
-import { DeviceCardLarge } from "../components/cards/device-card-large.tsx";
-import { DeviceCardSmall } from "../components/cards/device-card-small.tsx";
-import { Device } from "../data/frontend/contracts/device.model.ts";
-import { ReviewContract } from "../data/frontend/contracts/review.contract.ts";
-import { createSuperUserPocketBaseService } from "../data/pocketbase/pocketbase.service.ts";
-import { CustomFreshState } from "../interfaces/state.ts";
+import { DeviceCardLarge } from "@components/cards/device-card-large.tsx";
+import { DeviceCardSmall } from "@components/cards/device-card-small.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { ReviewContract } from "@data/frontend/contracts/review.contract.ts";
+import { createSuperUserPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/privacy.tsx
+++ b/routes/privacy.tsx
@@ -1,5 +1,5 @@
 import { FreshContext, page } from "fresh";
-import { CustomFreshState } from "../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/profile/index.tsx
+++ b/routes/profile/index.tsx
@@ -1,14 +1,14 @@
 import { PiChatCentered, PiPlus } from "@preact-icons/pi";
 import { FreshContext, page } from "fresh";
 import { RecordModel } from "npm:pocketbase";
-import { DeviceCardMedium } from "../../components/cards/device-card-medium.tsx";
-import { DeviceCollection } from "../../data/frontend/contracts/device-collection.ts";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { createLoggedInPocketBaseService } from "../../data/pocketbase/pocketbase.service.ts";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { SignOut } from "../../islands/auth/sign-out.tsx";
-import { DeviceCollections } from "../../islands/collections/device-collections.tsx";
-import { SuggestionForm } from "../../islands/profile/suggestion-form.tsx";
+import { DeviceCardMedium } from "@components/cards/device-card-medium.tsx";
+import { DeviceCollection } from "@data/frontend/contracts/device-collection.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { createLoggedInPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { SignOut } from "@islands/auth/sign-out.tsx";
+import { DeviceCollections } from "@islands/collections/device-collections.tsx";
+import { SuggestionForm } from "@islands/profile/suggestion-form.tsx";
 
 export const handler = {
   GET(ctx: FreshContext) {

--- a/routes/release-timeline/index.tsx
+++ b/routes/release-timeline/index.tsx
@@ -1,9 +1,9 @@
 import { PiCaretCircleDoubleDown } from "@preact-icons/pi";
 import { FreshContext, page, PageProps } from "fresh";
-import { Device } from "../../data/frontend/contracts/device.model.ts";
-import { DeviceService } from "../../data/frontend/services/devices/device.service.ts";
-import { CustomFreshState } from "../../interfaces/state.ts";
-import { TimelineContent } from "../../islands/devices/timeline-content.tsx";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { DeviceService } from "@data/frontend/services/devices/device.service.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
+import { TimelineContent } from "@islands/devices/timeline-content.tsx";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/routes/terms.tsx
+++ b/routes/terms.tsx
@@ -1,5 +1,5 @@
 import { FreshContext, page, PageProps } from "fresh";
-import { CustomFreshState } from "../interfaces/state.ts";
+import { CustomFreshState } from "@interfaces/state.ts";
 
 export const handler = {
   async GET(ctx: FreshContext) {

--- a/scripts/generate-devices.ts
+++ b/scripts/generate-devices.ts
@@ -1,6 +1,6 @@
 const command = new Deno.Command("deno", {
   args: ["run", "--allow-all", "data-source.ts"],
-  cwd: "../data/source",
+  cwd: "@data/source",
 });
 
 const process = command.spawn();

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-console
-import { Device } from "../data/frontend/contracts/device.model.ts";
-import { navigationItems } from "../data/frontend/navigation-items.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
+import { navigationItems } from "@data/frontend/navigation-items.ts";
 // @deno-types="https://deno.land/x/chalk_deno@v4.1.1-deno/index.d.ts"
 import chalk from "https://deno.land/x/chalk_deno@v4.1.1-deno/source/index.js";
 
@@ -9,7 +9,7 @@ const SITE_URL = "https://retroranker.site";
 
 const devices = JSON.parse(
   new TextDecoder().decode(
-    await Deno.readFile("../data/source/results/handhelds.json"),
+    await Deno.readFile("@data/source/results/handhelds.json"),
   ),
 ) as Device[];
 

--- a/scripts/get-new-sources.ts
+++ b/scripts/get-new-sources.ts
@@ -15,7 +15,7 @@ const zip = await zipDownloadedFromUrl.arrayBuffer();
 
 // save zip to local file
 const zipPath = "sources.zip";
-const extractPath = "data/source/files";
+const extractPath = "@data/source/files";
 
 // create extractPath if it doesn't exist
 await Deno.mkdir(extractPath, { recursive: true });

--- a/scripts/patch-devices.ts
+++ b/scripts/patch-devices.ts
@@ -1,6 +1,6 @@
 const command = new Deno.Command("deno", {
   args: ["run", "--allow-all", "device.patcher.ts"],
-  cwd: "../data/source/device-patcher",
+  cwd: "@data/source/device-patcher",
 });
 
 const process = command.spawn();

--- a/scripts/refresh-all.ts
+++ b/scripts/refresh-all.ts
@@ -21,7 +21,7 @@ if (!getNewSourcesStatus.success) {
 console.info("");
 const generateDevicesCommand = new Deno.Command("deno", {
   args: ["run", "--allow-all", "data-source.ts"],
-  cwd: "../data/source",
+  cwd: "@data/source",
 });
 
 const generateDevicesProcess = generateDevicesCommand.spawn();
@@ -76,7 +76,7 @@ console.info(chalk.blue("--- Refreshing pocketbase ---"));
 
 const refreshPocketbaseCommand = new Deno.Command(Deno.execPath(), {
   args: ["run", "--allow-all", "pocketbase-data-source.ts"],
-  cwd: "../data/source",
+  cwd: "@data/source",
 });
 const refreshPocketbaseProcess = refreshPocketbaseCommand.spawn();
 const refreshPocketbaseStatus = await refreshPocketbaseProcess.status;

--- a/scripts/scrape-images.ts
+++ b/scripts/scrape-images.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-console
-import { Device } from "../data/frontend/contracts/device.model.ts";
+import { Device } from "@data/frontend/contracts/device.model.ts";
 // @deno-types="https://deno.land/x/chalk_deno@v4.1.1-deno/index.d.ts"
 import chalk from "https://deno.land/x/chalk_deno@v4.1.1-deno/source/index.js";
 import { slugify } from "https://deno.land/x/slugify@0.3.0/mod.ts";
@@ -104,7 +104,7 @@ console.info(chalk.blue("Downloading device images..."));
 
 const devices = JSON.parse(
   new TextDecoder().decode(
-    await Deno.readFile("../data/source/results/handhelds.json"),
+    await Deno.readFile("@data/source/results/handhelds.json"),
   ),
 ) as Device[];
 


### PR DESCRIPTION
## Summary
- configure local module aliases in `deno.jsonc`
- switch project imports to new `@components`, `@data`, `@islands` and `@interfaces` aliases

## Testing
- `deno task check` *(fails: `deno` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459ac3ac4c833096171a65933674b1