### PR TITLE
Add folder READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ retro-ranker/
 └── main.ts     # Application entry point
 ```
 
+### Directory Guide
+
+- [`components/`](components/README.md) – reusable UI pieces
+- [`islands/`](islands/README.md) – client-side interactive components
+- [`routes/`](routes/README.md) – pages and API endpoints
+- [`scripts/`](scripts/README.md) – helper scripts for data management
+- [`data/`](data/README.md) – data models and source helpers
+- [`static/`](static/README.md) – images, icons and other static assets
+
 ## 🤝 Contributing
 
 Contributions are welcome! To contribute:

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,5 @@
+# Components
+
+Reusable UI components shared across multiple pages. Files are organized
+by feature (e.g. `cards/`, `auth/`). These components are rendered on the
+server and may be composed inside islands or routes.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,13 @@
+# Data
+
+Data models and utilities for working with device information. Important
+subdirectories include:
+
+- `entities/` – TypeScript interfaces representing our data models
+- `source/` – scripts and helpers that parse raw files into PocketBase
+- `pocketbase/` – local PocketBase instance used during development
+- `cap/`, `frontend/`, `pkce/`, `tracing/` – auxiliary data used by the
+  application
+
+Large result files in `source/results` and downloaded files in
+`source/files` are ignored in version control.

--- a/islands/README.md
+++ b/islands/README.md
@@ -1,0 +1,5 @@
+# Islands
+
+Interactive components that run only in the browser. Each folder groups
+related islands by feature. Islands are imported by routes or other
+components to add client-side behaviour.

--- a/routes/README.md
+++ b/routes/README.md
@@ -1,0 +1,8 @@
+# Routes
+
+Fresh pages and API endpoints. Each directory or file directly
+corresponds to a route on the site. Files beginning with an underscore
+such as `_app.tsx` or `_middleware.ts` provide global behavior.
+
+Route modules export a `handler` for API requests or a page component for
+server-side rendering.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,12 @@
+# Scripts
+
+Utility scripts used to manage data and housekeeping tasks. Each file can be
+executed with `deno run -A` or through the tasks defined in
+`deno.jsonc`.
+
+- `generate-devices.ts` – build device data from the source files
+- `patch-devices.ts` – apply patches to existing device data
+- `get-new-sources.ts` – download new source datasets
+- `refresh-all.ts` – run the full refresh pipeline
+- `scrape-images.ts` – fetch device images
+- `generate-sitemap.ts` – update `static/sitemap.xml`

--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,4 @@
+# Static
+
+Assets served as-is by the application. This includes images, icons and
+CSS. Files placed here are copied directly to the final build output.


### PR DESCRIPTION
## Summary
- document subfolders with concise READMEs
- link new docs from the root README via a directory guide

## Testing
- `deno task check` *(fails: `deno: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68459af8ec6c8330b068f084a1b65349