### PR TITLE
Refactor device card styles

### DIFF
--- a/components/cards/device-card-large.tsx
+++ b/components/cards/device-card-large.tsx
@@ -40,30 +40,8 @@ export function DeviceCardLarge({ device }: { device: Device }) {
   };
 
   return (
-    <article
-      class={`device-search-card`}
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        border: "1px solid var(--pico-primary)",
-        borderRadius: "0.5rem",
-      }}
-    >
-      <header
-        style={{
-          flex: 1,
-          margin: "0",
-          paddingTop: "0.5rem",
-          borderRadius: "0.5rem",
-          borderBottomLeftRadius: "0",
-          borderBottomRightRadius: "0",
-          borderBottom: "none",
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "space-evenly",
-          alignItems: "center",
-        }}
-      >
+    <article class="device-search-card device-card">
+      <header class="device-card-header device-card-header-row">
         {device.image?.originalUrl
           ? (
             <img
@@ -72,12 +50,7 @@ export function DeviceCardLarge({ device }: { device: Device }) {
               width={100}
               height={100}
               alt={device.image?.alt ?? "A device image"}
-              style={{
-                width: "100px",
-                height: "100px",
-                objectFit: "contain",
-                borderRadius: "1em",
-              }}
+              class="device-card-image"
             />
           )
           : (
@@ -87,23 +60,11 @@ export function DeviceCardLarge({ device }: { device: Device }) {
                 width={100}
                 height={100}
                 alt="A placeholder image"
-                style={{
-                  width: "100px",
-                  height: "100px",
-                  objectFit: "contain",
-                  borderRadius: "1em",
-                }}
+                class="device-card-image"
               />
             </span>
           )}
-        <hgroup
-          style={{
-            textAlign: "center",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
-        >
+        <hgroup class="device-card-hgroup">
           <strong
             data-tooltip={device.name.normalized != device.name.raw
               ? device.name.raw
@@ -122,38 +83,14 @@ export function DeviceCardLarge({ device }: { device: Device }) {
           >
             {device.brand.normalized}
           </span>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "baseline",
-              gap: "0.5rem",
-            }}
-          >
+          <div class="device-card-rating-row">
             <div style={{ display: "flex", justifyContent: "center" }}>
               <StarRating device={device} />
             </div>
           </div>
 
-          <div
-            style={{
-              marginBottom: ".5rem",
-              fontSize: ".8rem",
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "baseline",
-              gap: ".5rem",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                flexDirection: "column",
-              }}
-            >
+          <div class="device-card-stats">
+            <div class="device-card-price-container">
               {!device.pricing.discontinued && device.pricing.average
                 ? (
                   <span
@@ -174,12 +111,7 @@ export function DeviceCardLarge({ device }: { device: Device }) {
                 )}
             </div>
             <span
-              style={{
-                display: "flex",
-                gap: "0.25rem",
-                fontSize: "1.2rem",
-                marginTop: "0.5rem",
-              }}
+              class="device-card-os-icons"
               data-tooltip={device.os.list.join(", ") === "?"
                 ? "No OS information available"
                 : device.os.list.join(", ")}

--- a/components/cards/device-card-medium.tsx
+++ b/components/cards/device-card-medium.tsx
@@ -99,9 +99,7 @@ export function DeviceCardMedium(
           )}
       </div>
       <div class="device-card-stats">
-        <div
-          class="device-card-price-container"
-        >
+        <div class="device-card-price-container">
           {!device.pricing.discontinued && device.pricing.average
             ? (
               <span

--- a/components/cards/device-card-medium.tsx
+++ b/components/cards/device-card-medium.tsx
@@ -50,33 +50,10 @@ export function DeviceCardMedium(
 
   return (
     <article
-      class={`device-search-card ${isActive ? "active" : ""}`}
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        border: "1px solid var(--pico-primary)",
-        borderRadius: "0.5rem",
-      }}
+      class={`device-search-card device-card ${isActive ? "active" : ""}`}
     >
-      <header
-        style={{
-          flex: 1,
-          margin: "0",
-          paddingTop: "0.5rem",
-          borderRadius: "0.5rem",
-          borderBottomLeftRadius: "0",
-          borderBottomRightRadius: "0",
-          borderBottom: "none",
-        }}
-      >
-        <hgroup
-          style={{
-            textAlign: "center",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
-        >
+      <header class="device-card-header">
+        <hgroup class="device-card-hgroup">
           <strong
             data-tooltip={device.name.normalized != device.name.raw
               ? device.name.raw
@@ -97,15 +74,7 @@ export function DeviceCardMedium(
           </span>
         </hgroup>
       </header>
-      <div
-        style={{
-          paddingTop: "0.5rem",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
+      <div class="device-card-info">
         {device.image?.originalUrl
           ? (
             <img
@@ -114,12 +83,7 @@ export function DeviceCardMedium(
               width={100}
               height={100}
               alt={device.image?.alt ?? "A device image"}
-              style={{
-                width: "100px",
-                height: "100px",
-                objectFit: "contain",
-                borderRadius: "1em",
-              }}
+              class="device-card-image"
             />
           )
           : (
@@ -129,34 +93,14 @@ export function DeviceCardMedium(
                 width={100}
                 height={100}
                 alt="A placeholder image"
-                style={{
-                  width: "100px",
-                  height: "100px",
-                  objectFit: "contain",
-                  borderRadius: "1em",
-                }}
+                class="device-card-image"
               />
             </span>
           )}
       </div>
-
-      <div
-        style={{
-          marginBottom: ".5rem",
-          fontSize: ".8rem",
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "center",
-          alignItems: "baseline",
-          gap: ".5rem",
-        }}
-      >
+      <div class="device-card-stats">
         <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            flexDirection: "column",
-          }}
+          class="device-card-price-container"
         >
           {!device.pricing.discontinued && device.pricing.average
             ? (
@@ -178,12 +122,7 @@ export function DeviceCardMedium(
             )}
         </div>
         <span
-          style={{
-            display: "flex",
-            gap: "0.25rem",
-            fontSize: "1.2rem",
-            marginTop: "0.5rem",
-          }}
+          class="device-card-os-icons"
           data-tooltip={device.os.list.join(", ") === "?"
             ? "No OS information available"
             : device.os.list.join(", ")}
@@ -193,16 +132,7 @@ export function DeviceCardMedium(
           )}
         </span>
       </div>
-      <div
-        style={{
-          marginBottom: "0.5rem",
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "center",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
+      <div class="device-card-rating-row">
         {upToSystemA && (
           <RatingInfo
             rating={upToSystemA}

--- a/components/cards/device-card-row.tsx
+++ b/components/cards/device-card-row.tsx
@@ -15,13 +15,7 @@ export function DeviceCardRow({ device }: DeviceCardRowProps) {
   return (
     <div class="device-card-row">
       {/* Image Section */}
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
+      <div class="device-card-row-section">
         {device.image?.originalUrl
           ? (
             <img
@@ -30,12 +24,7 @@ export function DeviceCardRow({ device }: DeviceCardRowProps) {
               width={100}
               height={100}
               alt={device.image?.alt ?? "A device image"}
-              style={{
-                width: "100px",
-                height: "100px",
-                objectFit: "contain",
-                borderRadius: "1em",
-              }}
+              class="device-card-image"
             />
           )
           : (
@@ -45,26 +34,14 @@ export function DeviceCardRow({ device }: DeviceCardRowProps) {
                 width={100}
                 height={100}
                 alt="A placeholder image"
-                style={{
-                  width: "100px",
-                  height: "100px",
-                  objectFit: "contain",
-                  borderRadius: "1em",
-                }}
+                class="device-card-image"
               />
             </span>
           )}
       </div>
 
       {/* Name Section */}
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          textAlign: "center",
-        }}
-      >
+      <div class="device-card-row-section device-card-row-name">
         <strong style={{ color: "var(--pico-contrast)" }}>
           {device.name.raw} <span style={{ fontSize: "0.7rem" }}>by</span>{" "}
           <span
@@ -78,16 +55,7 @@ export function DeviceCardRow({ device }: DeviceCardRowProps) {
       </div>
 
       {/* Rating Section */}
-      <div
-        style={{
-          marginBottom: "0.5rem",
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "center",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
+      <div class="device-card-rating-row">
         {upToSystemA && (
           <RatingInfo
             rating={upToSystemA}
@@ -105,13 +73,7 @@ export function DeviceCardRow({ device }: DeviceCardRowProps) {
       </div>
 
       {/* Price Section */}
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
+      <div class="device-card-row-section">
         {device.pricing.average !== 0
           ? (
             <span

--- a/static/styles.css
+++ b/static/styles.css
@@ -2781,3 +2781,89 @@ textarea:focus {
 .devices-catalog-main {
   grid-area: main;
 }
+/* Device card reusable styles */
+.device-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--pico-primary);
+  border-radius: 0.5rem;
+}
+
+.device-card-header {
+  flex: 1;
+  margin: 0;
+  padding-top: 0.5rem;
+  border-radius: 0.5rem;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+}
+
+.device-card-header-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.device-card-hgroup {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.device-card-info {
+  padding-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.device-card-image {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+  border-radius: 1em;
+}
+
+.device-card-stats {
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.device-card-rating-row {
+  margin-bottom: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.device-card-os-icons {
+  display: flex;
+  gap: 0.25rem;
+  font-size: 1.2rem;
+  margin-top: 0.5rem;
+}
+
+.device-card-row-section {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.device-card-price-container {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+.device-card-row-name {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- centralize styles for device card components
- replace inline styles with class names for cleaner markup

## Testing
- `make check` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd999e408330a2c896e436c7d27e