### PR TITLE
Implement device/tag caching

### DIFF
--- a/data/frontend/services/devices/device.service.ts
+++ b/data/frontend/services/devices/device.service.ts
@@ -67,22 +67,26 @@ export class DeviceService {
 
   public async getAllDevices(forceRefresh = false): Promise<Device[]> {
     const now = Date.now();
-    if (!forceRefresh && this.devicesCache &&
-      now - this.devicesCache.timestamp < this.cacheDurationMs) {
+    if (
+      !forceRefresh && this.devicesCache &&
+      now - this.devicesCache.timestamp < this.cacheDurationMs
+    ) {
       return this.devicesCache.data;
     }
 
-    const data = (await this.pocketBaseService.getAll("devices")).map((device) =>
-      device.deviceData
-    );
+    const data = (await this.pocketBaseService.getAll("devices")).map((
+      device,
+    ) => device.deviceData);
     this.devicesCache = { data, timestamp: now };
     return data;
   }
 
   public async getAllTags(forceRefresh = false): Promise<TagModel[]> {
     const now = Date.now();
-    if (!forceRefresh && this.tagsCache &&
-      now - this.tagsCache.timestamp < this.cacheDurationMs) {
+    if (
+      !forceRefresh && this.tagsCache &&
+      now - this.tagsCache.timestamp < this.cacheDurationMs
+    ) {
       return this.tagsCache.data;
     }
 


### PR DESCRIPTION
## Summary
- add in-memory caches for device and tag queries
- use caches when getting devices, tags and by-name lookups
- update tag helpers to reuse cached data

## Testing
- `deno fmt data/frontend/services/devices/device.service.ts` *(fails: command not found)*
- `deno task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd95e4308330b5b871c463d7a8c7