### PR TITLE
Fix .gitignore for deno.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ deno_cache/
 build/
 
 # Deno lock
+deno.lock


### PR DESCRIPTION
## Summary
- ignore `deno.lock` in `.gitignore`

## Testing
- `deno task check` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f2e5acf88330bb729ecfe239804c