### PR TITLE
Update README env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ deno task start
 deno task check
 ```
 
+#### Environment Setup
+
+Copy the sample environment file and adjust the values:
+
+```bash
+cp .env.example .env
+```
+
+Environment variables in `.env`:
+
+- `BASE_API_URL` – Base URL for the API.
+- `POCKETBASE_URL` – Address of your PocketBase instance.
+- `POCKETBASE_SUPERUSER_EMAIL` – PocketBase superuser email.
+- `POCKETBASE_SUPERUSER_PASSWORD` – Password for the superuser account.
+- `OTEL_*` – OpenTelemetry settings (`OTEL_DENO`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`).
+
+Refer to `.env.defaults` for example values used with local `docker-compose`.
+
 ### Available Tasks
 
 #### Development Tasks


### PR DESCRIPTION
## Summary
- document how to create `.env` from `.env.example`
- describe all environment variables
- link `.env.defaults` for docker-compose usage

## Testing
- `deno task check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f2cab7c08330adba33aaa5a1a2d9