### PR TITLE
Fix main logo alt text

### DIFF
--- a/islands/navigation/desktop-nav.tsx
+++ b/islands/navigation/desktop-nav.tsx
@@ -109,7 +109,7 @@ export function DesktopNav(
                 <img
                   loading="lazy"
                   src="/logos/retro-ranker/rr-logo.svg"
-                  alt="logo"
+                  alt="retro ranker logo"
                   width="100"
                   style={{
                     height: "2.5em",

--- a/islands/navigation/mobile-nav.tsx
+++ b/islands/navigation/mobile-nav.tsx
@@ -131,7 +131,7 @@ export function MobileNav(
             <img
               loading="lazy"
               src="/logos/retro-ranker/rr-logo.svg"
-              alt="logo"
+              alt="retro ranker logo"
               width="100"
               style={{
                 height: "3em",


### PR DESCRIPTION
## Summary
- update alt text for the main navigation logo to "retro ranker logo"

## Testing
- `make check` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb45a6db48330b3f42226ddbc87d9