### PR TITLE
Add basic i18n infrastructure

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -6,8 +6,13 @@ import {
   PiShield,
 } from "@preact-icons/pi";
 import { VersionTag } from "./shared/version-tag.tsx";
+import { LanguageSwitcher } from "@islands/navigation/language-switcher.tsx";
+import { TranslationPipe } from "@data/frontend/services/i18n/i18n.service.ts";
 
-export function Footer() {
+export function Footer(
+  { translations }: { translations: Record<string, string> },
+) {
+  const t = (key: string) => TranslationPipe(translations, key);
   return (
     <footer
       style={{
@@ -26,13 +31,13 @@ export function Footer() {
               alignItems: "center",
             }}
           >
-            <span>Other</span>
+            <span>{t("footer.other")}</span>
             <ul class="footer-grid-item-list">
               <li style={{ listStyle: "none" }}>
                 <a href="/privacy">
                   <div style={{ display: "flex" }}>
                     <PiShield />
-                    <span>&nbsp;Privacy</span>
+                    <span>&nbsp;{t("footer.privacy")}</span>
                   </div>
                 </a>
               </li>
@@ -41,7 +46,7 @@ export function Footer() {
                 <a href="/terms">
                   <div style={{ display: "flex" }}>
                     <PiFileText />
-                    <span>&nbsp;ToS</span>
+                    <span>&nbsp;{t("footer.tos")}</span>
                   </div>
                 </a>
               </li>
@@ -56,7 +61,7 @@ export function Footer() {
               alignItems: "center",
             }}
           >
-            <span>Connect</span>
+            <span>{t("footer.connect")}</span>
             <ul class="footer-grid-item-list">
               <li style={{ listStyle: "none" }}>
                 <a
@@ -65,7 +70,7 @@ export function Footer() {
                 >
                   <div style={{ display: "flex" }}>
                     <PiChatText />
-                    <span>&nbsp;Bluesky</span>
+                    <span>&nbsp;{t("footer.bluesky")}</span>
                   </div>
                 </a>
               </li>
@@ -76,7 +81,7 @@ export function Footer() {
                 >
                   <div style={{ display: "flex" }}>
                     <PiGithubLogo />
-                    <span>&nbsp;GitHub</span>
+                    <span>&nbsp;{t("footer.github")}</span>
                   </div>
                 </a>
               </li>
@@ -91,13 +96,13 @@ export function Footer() {
               alignItems: "center",
             }}
           >
-            <span>More</span>
+            <span>{t("footer.more")}</span>
             <ul class="footer-grid-item-list">
               <li style={{ listStyle: "none" }}>
                 <a href="/about">
                   <div style={{ display: "flex" }}>
                     <PiInfo />
-                    <span>&nbsp;About</span>
+                    <span>&nbsp;{t("footer.about")}</span>
                   </div>
                 </a>
               </li>
@@ -105,7 +110,7 @@ export function Footer() {
                 <a href="/contact">
                   <div style={{ display: "flex" }}>
                     <PiChatText />
-                    <span>&nbsp;Contact</span>
+                    <span>&nbsp;{t("footer.contact")}</span>
                   </div>
                 </a>
               </li>
@@ -122,6 +127,7 @@ export function Footer() {
 
               <VersionTag />
             </div>
+            <LanguageSwitcher />
             <small>
               © {new Date().getFullYear()}{" "}
               <a

--- a/data/frontend/languages.ts
+++ b/data/frontend/languages.ts
@@ -1,0 +1,19 @@
+export const languages = [
+  "en-US",
+  "en-GB",
+  "de-DE",
+  "fr-FR",
+  "es-ES",
+  "nl-NL",
+  "pt-PT",
+] as const;
+
+export const languageNames: Record<string, string> = {
+  "en-US": "English (US)",
+  "en-GB": "English (UK)",
+  "de-DE": "Deutsch",
+  "fr-FR": "Français",
+  "es-ES": "Español",
+  "nl-NL": "Nederlands",
+  "pt-PT": "Português",
+};

--- a/data/frontend/navigation-items.ts
+++ b/data/frontend/navigation-items.ts
@@ -1,5 +1,6 @@
 export interface NavigationItem {
   label: string;
+  i18nKey?: string;
   href: string;
   icon?: string;
   isActive: (pathname: string) => boolean;
@@ -10,6 +11,7 @@ export const navigationItems: NavigationItem[] = [
   {
     href: "/devices",
     label: "Devices",
+    i18nKey: "nav.devices",
     icon: "PiScroll",
     isActive: (pathname) => pathname.startsWith("/devices"),
     priority: 0.9,
@@ -17,6 +19,7 @@ export const navigationItems: NavigationItem[] = [
   {
     href: "/release-timeline",
     label: "Releases",
+    i18nKey: "nav.releases",
     icon: "PiCalendar",
     isActive: (pathname) => pathname.startsWith("/release-timeline"),
     priority: 0.8,
@@ -24,6 +27,7 @@ export const navigationItems: NavigationItem[] = [
   {
     href: "/compare",
     label: "Compare",
+    i18nKey: "nav.compare",
     icon: "PiGitDiff",
     isActive: (pathname) => pathname.startsWith("/compare"),
     priority: 0.9,
@@ -31,6 +35,7 @@ export const navigationItems: NavigationItem[] = [
   {
     href: "/leaderboard",
     label: "Leaderboard",
+    i18nKey: "nav.leaderboard",
     icon: "PiRanking",
     isActive: (pathname) => pathname.startsWith("/leaderboard"),
     priority: 0.7,
@@ -38,6 +43,7 @@ export const navigationItems: NavigationItem[] = [
   {
     href: "/charts",
     label: "Charts",
+    i18nKey: "nav.charts",
     icon: "PiChartLine",
     isActive: (pathname) => pathname.startsWith("/charts"),
     priority: 0.7,
@@ -45,6 +51,7 @@ export const navigationItems: NavigationItem[] = [
   {
     href: "/faq",
     label: "FAQ",
+    i18nKey: "nav.faq",
     icon: "PiQuestion",
     isActive: (pathname) => pathname === "/faq",
     priority: 0.6,

--- a/data/frontend/services/i18n/i18n.service.ts
+++ b/data/frontend/services/i18n/i18n.service.ts
@@ -1,0 +1,33 @@
+const cache = new Map<string, Record<string, string>>();
+
+export async function getTranslations(
+  lang: string,
+): Promise<Record<string, string>> {
+  if (cache.has(lang)) return cache.get(lang)!;
+  try {
+    const module = await import(`../../../../static/i18n/${lang}.json`, {
+      assert: { type: "json" },
+    });
+    const data = module.default as Record<string, string>;
+    cache.set(lang, data);
+    return data;
+  } catch {
+    if (lang !== "en-US") {
+      return await getTranslations("en-US");
+    }
+    return {};
+  }
+}
+
+/**
+ * Lookup a translation key in the given translation map.
+ *
+ * The function is named "TranslationPipe" so it can easily be imported and
+ * reused across components without redefining the helper each time.
+ */
+export function TranslationPipe(
+  translations: Record<string, string>,
+  key: string,
+): string {
+  return translations[key] ?? key;
+}

--- a/interfaces/state.ts
+++ b/interfaces/state.ts
@@ -15,4 +15,6 @@ export interface CustomFreshState {
   user?: User | null;
   seo?: SeoData | null;
   data?: any | null;
+  language?: string;
+  translations?: Record<string, string>;
 }

--- a/islands/navigation/desktop-nav.tsx
+++ b/islands/navigation/desktop-nav.tsx
@@ -19,21 +19,28 @@ import { Device } from "@data/frontend/contracts/device.model.ts";
 import { User } from "@data/frontend/contracts/user.contract.ts";
 import { navigationItems } from "@data/frontend/navigation-items.ts";
 import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
+import { TranslationPipe } from "@data/frontend/services/i18n/i18n.service.ts";
 import { ThemeSwitcher } from "./theme-switcher.tsx";
+import { LanguageSwitcher } from "./language-switcher.tsx";
 
 export function DesktopNav({
   pathname,
   allDevices,
   user,
+  translations,
+  language,
 }: {
   pathname: string;
   allDevices: Device[];
   user: User | null;
+  translations: Record<string, string>;
+  language: string;
 }) {
   const suggestionsRef = useRef<HTMLUListElement>(null);
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
   const [suggestions, setSuggestions] = useState<Device[]>([]);
   const [query, setQuery] = useState<string>("");
+  const t = (key: string) => TranslationPipe(translations, key);
   const isActive = (deviceName: string) => {
     return deviceName.toLowerCase() === selectedDevice?.name.raw.toLowerCase();
   };
@@ -130,7 +137,7 @@ export function DesktopNav({
               <a
                 href={item.href}
                 class={item.isActive(pathname) ? "nav-a active" : "nav-a"}
-                aria-label={item.label}
+                aria-label={t(item.i18nKey ?? item.label)}
               >
                 <span class="nav-item-label">
                   <span
@@ -139,7 +146,7 @@ export function DesktopNav({
                   >
                     {item.icon && getIcon(item.icon)}
                   </span>
-                  {item.label}
+                  {t(item.i18nKey ?? item.label)}
                 </span>
               </a>
             </li>
@@ -173,8 +180,11 @@ export function DesktopNav({
               onClick={handleSubmit}
             >
               <PiMagnifyingGlass />
-              <span style={{ marginLeft: "0.25rem" }}>Go</span>
+              <span style={{ marginLeft: "0.25rem" }}>{t("nav.go")}</span>
             </button>
+          </li>
+          <li class="nav-theme-item">
+            <LanguageSwitcher />
           </li>
           <li class="nav-theme-item">
             <ThemeSwitcher showNames={false} showTooltip={true} />

--- a/islands/navigation/language-switcher.tsx
+++ b/islands/navigation/language-switcher.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "preact/hooks";
+import { languageNames, languages } from "@data/frontend/languages.ts";
+
+export function LanguageSwitcher() {
+  const [lang, setLang] = useState<string>("en-US");
+
+  useEffect(() => {
+    const saved = localStorage.getItem("language");
+    if (saved) {
+      setLang(saved);
+    } else if (document.documentElement.lang) {
+      setLang(document.documentElement.lang);
+    }
+  }, []);
+
+  const change = (e: Event) => {
+    const value = (e.currentTarget as HTMLSelectElement).value;
+    setLang(value);
+    localStorage.setItem("language", value);
+    document.cookie = `lang=${value}; path=/; max-age=31536000`;
+    location.reload();
+  };
+
+  return (
+    <select value={lang} onChange={change} aria-label="Select language">
+      {languages.map((code) => (
+        <option value={code}>{languageNames[code]}</option>
+      ))}
+    </select>
+  );
+}

--- a/islands/navigation/mobile-nav.tsx
+++ b/islands/navigation/mobile-nav.tsx
@@ -4,6 +4,7 @@ import { Device } from "@data/frontend/contracts/device.model.ts";
 import { User } from "@data/frontend/contracts/user.contract.ts";
 import { getAllNavigationItems } from "@data/frontend/navigation-items.ts";
 import { searchDevices } from "@data/frontend/services/utils/search.utils.ts";
+import { TranslationPipe } from "@data/frontend/services/i18n/i18n.service.ts";
 import {
   PiCalendar,
   PiChartLine,
@@ -19,15 +20,20 @@ import {
 } from "@preact-icons/pi";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { ThemeSwitcher } from "./theme-switcher.tsx";
+import { LanguageSwitcher } from "./language-switcher.tsx";
 
 export function MobileNav({
   pathname,
   allDevices,
   user,
+  translations,
+  language,
 }: {
   pathname: string;
   allDevices: Device[];
   user: User | null;
+  translations: Record<string, string>;
+  language: string;
 }) {
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -60,6 +66,7 @@ export function MobileNav({
   const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
   const [suggestions, setSuggestions] = useState<Device[]>([]);
   const [query, setQuery] = useState<string>("");
+  const t = (key: string) => TranslationPipe(translations, key);
   const isActive = (deviceName: string) => {
     return deviceName.toLowerCase() === selectedDevice?.name.raw.toLowerCase();
   };
@@ -165,7 +172,7 @@ export function MobileNav({
               onClick={handleSubmit}
             >
               <PiMagnifyingGlass />
-              <span style={{ marginLeft: "0.25rem" }}>Go</span>
+              <span style={{ marginLeft: "0.25rem" }}>{t("nav.go")}</span>
             </button>
           </div>
 
@@ -184,6 +191,7 @@ export function MobileNav({
 
           <div class="mobile-nav-theme-switcher">
             <ThemeSwitcher showTooltip={false} showNames={false} />
+            <LanguageSwitcher />
           </div>
         </div>
         <div
@@ -209,7 +217,7 @@ export function MobileNav({
                     }}
                   >
                     {item.icon && getIcon(item.icon)}
-                    &nbsp;{item.label}
+                    &nbsp;{t(item.i18nKey ?? item.label)}
                   </span>
                 </a>
               </li>

--- a/islands/navigation/top-navbar.tsx
+++ b/islands/navigation/top-navbar.tsx
@@ -5,10 +5,12 @@ import { DesktopNav } from "./desktop-nav.tsx";
 import { MobileNav } from "./mobile-nav.tsx";
 
 export function TopNavbar(
-  { pathname, allDevices, user }: {
+  { pathname, allDevices, user, translations, language }: {
     pathname: string;
     allDevices: Device[];
     user: User | null;
+    translations: Record<string, string>;
+    language: string;
   },
 ) {
   const [isMobile, setIsMobile] = useState(false);
@@ -51,12 +53,22 @@ export function TopNavbar(
   return (
     <>
       {isMobile
-        ? <MobileNav pathname={pathname} allDevices={allDevices} user={user} />
+        ? (
+          <MobileNav
+            pathname={pathname}
+            allDevices={allDevices}
+            user={user}
+            translations={translations}
+            language={language}
+          />
+        )
         : (
           <DesktopNav
             pathname={pathname}
             allDevices={allDevices}
             user={user}
+            translations={translations}
+            language={language}
           />
         )}
     </>

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -28,10 +28,12 @@ export default function AppWrapper(
   const params = ctx.params as any;
   const allDevices = params.allDevices as Device[];
   const user = (ctx.state as CustomFreshState).user as User | null;
+  const language = (ctx.state as CustomFreshState).language ?? "en-US";
+  const translations = (ctx.state as CustomFreshState).translations ?? {};
   const url = new URL(ctx.req.url);
 
   const page = (
-    <html class="transition-colors" lang="en">
+    <html class="transition-colors" lang={language}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -100,18 +102,35 @@ export default function AppWrapper(
             `,
           }}
         />
+        <script
+          defer
+          // deno-lint-ignore react-no-danger
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                const savedLang = localStorage.getItem('language');
+                if (savedLang) {
+                  document.cookie = 'lang=' + savedLang + '; path=/; max-age=31536000';
+                  document.documentElement.setAttribute('lang', savedLang);
+                }
+              })();
+            `,
+          }}
+        />
       </head>
       <body>
         <TopNavbar
           pathname={url.pathname}
           allDevices={allDevices}
           user={user}
+          translations={translations}
+          language={language}
         />
         <main class="main-content">
           {/* @ts-ignore */}
           <ctx.Component />
         </main>
-        <Footer />
+        <Footer translations={translations} language={language} />
       </body>
     </html>
   );

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -3,6 +3,8 @@ import { FreshContext } from "fresh";
 import { createPocketBaseService } from "@data/pocketbase/pocketbase.service.ts";
 import { logJson, tracer } from "@data/tracing/tracer.ts";
 import { CustomFreshState } from "@interfaces/state.ts";
+import { getTranslations } from "@data/frontend/services/i18n/i18n.service.ts";
+import { getCookies } from "@std/http/cookie";
 
 // List of file extensions to ignore for logging
 const IGNORED_EXTENSIONS = new Set([
@@ -53,6 +55,12 @@ export async function handler(ctx: FreshContext) {
   const req = ctx.req;
   const url = new URL(req.url);
   const path = url.pathname;
+  const cookies = getCookies(req.headers);
+  const language = cookies.lang ?? "en-US";
+  (ctx.state as CustomFreshState).language = language;
+  (ctx.state as CustomFreshState).translations = await getTranslations(
+    language,
+  );
 
   return await tracer.startActiveSpan(`route:${path}`, async (span) => {
     try {

--- a/static/i18n/de-DE.json
+++ b/static/i18n/de-DE.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Geräte",
+  "nav.releases": "Veröffentlichungen",
+  "nav.compare": "Vergleichen",
+  "nav.leaderboard": "Bestenliste",
+  "nav.charts": "Diagramme",
+  "nav.faq": "FAQ",
+  "nav.go": "Los",
+  "footer.other": "Sonstiges",
+  "footer.privacy": "Datenschutz",
+  "footer.tos": "Nutzungsbedingungen",
+  "footer.connect": "Verbinden",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "Mehr",
+  "footer.about": "Über uns",
+  "footer.contact": "Kontakt"
+}

--- a/static/i18n/en-GB.json
+++ b/static/i18n/en-GB.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Devices",
+  "nav.releases": "Releases",
+  "nav.compare": "Compare",
+  "nav.leaderboard": "Leaderboard",
+  "nav.charts": "Charts",
+  "nav.faq": "FAQ",
+  "nav.go": "Go",
+  "footer.other": "Other",
+  "footer.privacy": "Privacy",
+  "footer.tos": "ToS",
+  "footer.connect": "Connect",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "More",
+  "footer.about": "About",
+  "footer.contact": "Contact"
+}

--- a/static/i18n/en-US.json
+++ b/static/i18n/en-US.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Devices",
+  "nav.releases": "Releases",
+  "nav.compare": "Compare",
+  "nav.leaderboard": "Leaderboard",
+  "nav.charts": "Charts",
+  "nav.faq": "FAQ",
+  "nav.go": "Go",
+  "footer.other": "Other",
+  "footer.privacy": "Privacy",
+  "footer.tos": "ToS",
+  "footer.connect": "Connect",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "More",
+  "footer.about": "About",
+  "footer.contact": "Contact"
+}

--- a/static/i18n/es-ES.json
+++ b/static/i18n/es-ES.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Dispositivos",
+  "nav.releases": "Lanzamientos",
+  "nav.compare": "Comparar",
+  "nav.leaderboard": "Clasificación",
+  "nav.charts": "Gráficos",
+  "nav.faq": "FAQ",
+  "nav.go": "Ir",
+  "footer.other": "Otro",
+  "footer.privacy": "Privacidad",
+  "footer.tos": "Términos",
+  "footer.connect": "Conectar",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "Más",
+  "footer.about": "Acerca de",
+  "footer.contact": "Contacto"
+}

--- a/static/i18n/fr-FR.json
+++ b/static/i18n/fr-FR.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Appareils",
+  "nav.releases": "Sorties",
+  "nav.compare": "Comparer",
+  "nav.leaderboard": "Classement",
+  "nav.charts": "Graphiques",
+  "nav.faq": "FAQ",
+  "nav.go": "Aller",
+  "footer.other": "Autre",
+  "footer.privacy": "Confidentialité",
+  "footer.tos": "Conditions",
+  "footer.connect": "Connecter",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "Plus",
+  "footer.about": "À propos",
+  "footer.contact": "Contact"
+}

--- a/static/i18n/nl-NL.json
+++ b/static/i18n/nl-NL.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Apparaten",
+  "nav.releases": "Releases",
+  "nav.compare": "Vergelijken",
+  "nav.leaderboard": "Ranglijst",
+  "nav.charts": "Grafieken",
+  "nav.faq": "FAQ",
+  "nav.go": "Ga",
+  "footer.other": "Overig",
+  "footer.privacy": "Privacy",
+  "footer.tos": "Voorwaarden",
+  "footer.connect": "Verbind",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "Meer",
+  "footer.about": "Over",
+  "footer.contact": "Contact"
+}

--- a/static/i18n/pt-PT.json
+++ b/static/i18n/pt-PT.json
@@ -1,0 +1,18 @@
+{
+  "nav.devices": "Dispositivos",
+  "nav.releases": "Lançamentos",
+  "nav.compare": "Comparar",
+  "nav.leaderboard": "Classificação",
+  "nav.charts": "Gráficos",
+  "nav.faq": "FAQ",
+  "nav.go": "Ir",
+  "footer.other": "Outro",
+  "footer.privacy": "Privacidade",
+  "footer.tos": "Termos",
+  "footer.connect": "Conectar",
+  "footer.bluesky": "Bluesky",
+  "footer.github": "GitHub",
+  "footer.more": "Mais",
+  "footer.about": "Sobre",
+  "footer.contact": "Contato"
+}


### PR DESCRIPTION
## Summary
- implement translation service and supported language list
- add language switcher island
- translate navbar and footer
- load translations server side via middleware
- sync chosen language using cookie/localstorage
- include example translation files
- centralize translation helper as `TranslationPipe`

## Testing
- `deno task check` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6866de24ac7483309c3b589389c7c8c5