### PR TITLE
Adjust mobile layout for home device grid

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1090,13 +1090,17 @@ body.paused-animation::before {
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(2, 1fr);
 
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+  }
+
   @media (max-width: 425px) {
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(3, 1fr);
+    grid-template-columns: 1fr;
   }
 
   @media (max-width: 320px) {
-    grid-template-columns: repeat(1, 1fr);
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the home page device grid to collapse into a single column on small screens so cards no longer overflow on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24d59383483308fab3b6a132b0a06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout: device grid now adapts from three columns on desktop to a single column on tablets and phones.
  * Updated breakpoints to ensure consistent single-column behavior on smaller screens, including very small devices.
  * Enhances readability, scrolling, and touch usability for mobile users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->